### PR TITLE
Refactor priority system using enums for better readability and safety

### DIFF
--- a/src/main/java/max/command/AddCommand.java
+++ b/src/main/java/max/command/AddCommand.java
@@ -4,6 +4,7 @@ import max.exception.MaxException;
 import max.storage.Storage;
 import max.task.Deadline;
 import max.task.Event;
+import max.task.Priority;
 import max.task.Task;
 import max.task.TaskList;
 import max.task.ToDo;
@@ -15,6 +16,7 @@ import max.ui.Ui;
 public class AddCommand extends Command {
     private final String type;
     private final String description;
+    private final Priority priority;
 
     /**
      * Constructs an AddCommand with the specified task type and description.
@@ -22,9 +24,10 @@ public class AddCommand extends Command {
      * @param type        The type of task (todo, deadline, event).
      * @param description The description of the task.
      */
-    public AddCommand(String type, String description) {
+    public AddCommand(String type, String description, Priority priority) {
         this.type = type;
         this.description = description;
+        this.priority = priority;
     }
 
     /**
@@ -61,6 +64,7 @@ public class AddCommand extends Command {
             throw new MaxException("Invalid task type!");
         }
 
+        task.setPriority(priority);
         tasks.addTask(task);
         storage.save(tasks.getTasks());
         return "Got it. I've added this task:\n  " + task + "\nNow you have " + tasks.size() + " tasks in the list.";

--- a/src/main/java/max/command/ListCommand.java
+++ b/src/main/java/max/command/ListCommand.java
@@ -1,15 +1,23 @@
 package max.command;
 
 import max.storage.Storage;
+import max.task.Task;
 import max.task.TaskList;
 import max.ui.Ui;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 public class ListCommand extends Command{
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        List<Task> sortedTasks = tasks.getTasks().stream()
+                .sorted((t1, t2) -> Integer.compare(t2.getPriority().getLevel(), t1.getPriority().getLevel()))
+                .collect(Collectors.toList());
+
         StringBuilder response = new StringBuilder("Here are the tasks in your list:\n");
-        for (int i = 0; i < tasks.size(); i++) {
+        for (int i = 0; i < sortedTasks.size(); i++) {
             response.append((i + 1)).append(". ").append(tasks.getTask(i)).append("\n");
         }
         return response.toString();

--- a/src/main/java/max/command/PriorityCommand.java
+++ b/src/main/java/max/command/PriorityCommand.java
@@ -1,0 +1,35 @@
+package max.command;
+
+import max.exception.MaxException;
+import max.storage.Storage;
+import max.task.Priority;
+import max.task.Task;
+import max.task.TaskList;
+import max.ui.Ui;
+
+/**
+ * Represents a command to update a task's priority.
+ */
+public class PriorityCommand extends Command {
+    private final int index;
+    private final Priority priority;
+
+    public PriorityCommand(int index, Priority priority) {
+        this.index = index;
+        this.priority = priority;
+    }
+
+    @Override
+    public String execute(TaskList tasks, Ui ui, Storage storage) throws MaxException {
+        int taskIndex = index - 1;
+        if (taskIndex < 0 || taskIndex >= tasks.size()) {
+            throw new MaxException("Invalid task number!");
+        }
+
+        Task task = tasks.getTask(taskIndex);
+        task.setPriority(priority);
+        storage.save(tasks.getTasks());
+
+        return "Updated priority for task:\n  " + task;
+    }
+}

--- a/src/main/java/max/parser/Parser.java
+++ b/src/main/java/max/parser/Parser.java
@@ -2,6 +2,7 @@ package max.parser;
 
 import max.command.*;
 import max.exception.MaxException;
+import max.task.Priority;
 
 /**
  * Parses user input and returns the corresponding command.
@@ -23,11 +24,11 @@ public class Parser {
         case "list":
             return new ListCommand();
         case "todo":
-            return new AddCommand("todo", arguments);
+            return new AddCommand("todo", arguments, Priority.LOW);
         case "deadline":
-            return new AddCommand("deadline", arguments);
+            return new AddCommand("deadline", arguments, Priority.LOW);
         case "event":
-            return new AddCommand("event", arguments);
+            return new AddCommand("event", arguments, Priority.LOW);
         case "mark":
             return new MarkCommand(true, Integer.parseInt(arguments));
         case "unmark":
@@ -43,6 +44,13 @@ public class Parser {
             return new FindCommand(arguments);
         case "bye":
             return new ExitCommand();
+        case "priority":
+            if (inputParts.length < 3) {
+                throw new MaxException("Priority command format: priority [task number] [low/medium/high]");
+            }
+            int taskIndex = Integer.parseInt(inputParts[1]);
+            Priority priority = Priority.valueOf(inputParts[2].toUpperCase()); // Convert string to enum
+            return new PriorityCommand(taskIndex, priority);
         default:
             throw new MaxException("Oh no! Unknown command! Did you mean 'todo', 'deadline', 'event', or 'find'?");
         }

--- a/src/main/java/max/task/Priority.java
+++ b/src/main/java/max/task/Priority.java
@@ -1,0 +1,34 @@
+package max.task;
+
+/**
+ * Represents the priority levels for tasks.
+ */
+public enum Priority {
+    LOW(1), MEDIUM(2), HIGH(3);
+
+    private final int level;
+
+    Priority(int level) {
+        this.level = level;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    /**
+     * Converts an integer priority value to a Priority enum.
+     * Defaults to LOW if an invalid value is provided.
+     */
+    public static Priority fromInt(int level) {
+        switch (level) {
+        case 3:
+            return HIGH;
+        case 2:
+            return MEDIUM;
+        case 1:
+        default:
+            return LOW;
+        }
+    }
+}

--- a/src/main/java/max/task/Task.java
+++ b/src/main/java/max/task/Task.java
@@ -3,9 +3,11 @@ package max.task;
 public abstract class Task {
     protected String description;
     protected boolean isDone;
+    protected Priority priority;
     public Task(String description) {
         this.description = description;
         this.isDone = false;
+        this.priority = Priority.LOW;
     }
 
     /**
@@ -20,6 +22,15 @@ public abstract class Task {
     public String getStatusIcon() {
         return (isDone ? "X" : " "); // mark done task with X
     }
+
+    public Priority getPriority() {
+        return priority;
+    }
+
+    public void setPriority(Priority priority) {
+        this.priority = priority;
+    }
+
     public void markAsDone(){
         this.isDone = true;
         System.out.println("Nice! I've marked this task as done:\n [X] " + this.description);


### PR DESCRIPTION
Previously, priority was managed as an integer, making it prone to errors and difficult to understand. The system lacked clarity and enforced priority levels using arbitrary numbers.

Let's introduce an `enum` for `Priority` and refactor:
- `Task` now stores priority as `Priority` instead of `int`.
- `AddCommand` and `PriorityCommand` updated to use enums.
- `Parser` accepts `priority low/medium/high` instead of numbers.
- `ListCommand` sorts tasks by priority using Streams.
- Ensured type safety and improved maintainability.

This refactoring improves code clarity, prevents invalid priority values, and makes comparisons more intuitive.